### PR TITLE
Do not rebuild when packing in GitHub Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,12 +20,9 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build -t:build,pack --configuration Release --no-restore
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal
-
-    - name: Pack
-      run: dotnet pack OfxNet/OfxNet.csproj --configuration Release
 
     - name: Publish NuGet
       run: dotnet nuget push **/*.nupkg --api-key ${{secrets.NUGET_APIKEY}} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
`dotnet pack` will build everything again, modulo whatever msbuild's 'incremental build' wants to skip, which isn't great.
Adding `--no-build` to the `dotnet pack` command is better, but it is a bit fragile and can cause build failures if your build authoring ever trips over invoking the build target.
The best solution to this is usually to build and pack at the same time, since that's reliable and fast.