### PR TITLE
Add support to load from Stream

### DIFF
--- a/src/OfxNet/OfxDocument.cs
+++ b/src/OfxNet/OfxDocument.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
@@ -28,17 +29,29 @@ public class OfxDocument
         return Load(path, OfxDocumentSettings.Default);
     }
 
+    public static OfxDocument Load(Stream stream)
+    {
+        return Load(stream, OfxDocumentSettings.Default);
+    }
+
     public static OfxDocument Load(string path, OfxDocumentSettings settings)
+    {
+        using FileStream stream = File.OpenRead(path);
+
+        return Load(stream, settings);
+    }
+
+    public static OfxDocument Load(Stream stream, OfxDocumentSettings settings)
     {
         OfxDocument result;
 
-        if (SgmlDocument.TryLoad(path, out SgmlDocument? sgmlDocument))
+        if (SgmlDocument.TryLoad(stream, out SgmlDocument? sgmlDocument))
         {
             result = new OfxDocument(sgmlDocument, settings);
         }
         else
         {
-            result = new OfxDocument(XDocument.Load(path), settings);
+            result = new OfxDocument(XDocument.Load(stream), settings);
         }
 
         return result;

--- a/src/OfxNet/Sgml/SgmlDocument.cs
+++ b/src/OfxNet/Sgml/SgmlDocument.cs
@@ -17,14 +17,21 @@ public class SgmlDocument
 
     public static bool TryLoad(string path, [NotNullWhen(true)] out SgmlDocument? result)
     {
+        using FileStream stream = File.OpenRead(path);
+
+        return TryLoad(stream, out result);
+    }
+
+    public static bool TryLoad(Stream stream, [NotNullWhen(true)] out SgmlDocument? result)
+    {
         result = null;
 
-        SgmlHeader? header = new SgmlHeaderParser().TryGetHeader(path);
+        SgmlHeader? header = new SgmlHeaderParser().TryGetHeader(stream);
         if (header != default)
         {
             Encoding encoding = header.GetEncoding();
 
-            SgmlElement root = new SgmlParser().Parse(path, encoding);
+            SgmlElement root = new SgmlParser().Parse(stream, encoding);
             if (root != SgmlElement.Empty)
             {
                 result = new SgmlDocument(header, root);

--- a/src/OfxNet/Sgml/SgmlHeaderParser.cs
+++ b/src/OfxNet/Sgml/SgmlHeaderParser.cs
@@ -14,11 +14,26 @@ public class SgmlHeaderParser
 
     public SgmlHeader? TryGetHeader(string path)
     {
-        using StreamReader stream = new (path, Encoding.ASCII);
+        using FileStream stream = File.OpenRead(path);
 
-        OfxVersion headerVersion = this.TryGetOfxHeaderVersion(stream);
+        return this.TryGetHeader(stream);
+    }
 
-        return (headerVersion == OfxVersion.HeaderV1) ? this.GetHeader(stream, headerVersion) : default;
+    public SgmlHeader? TryGetHeader(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var streamStartPosition = stream.Position;
+
+        using StreamReader reader = new(stream, Encoding.ASCII, leaveOpen: true);
+
+        OfxVersion headerVersion = this.TryGetOfxHeaderVersion(reader);
+
+        SgmlHeader? result = (headerVersion == OfxVersion.HeaderV1) ? this.GetHeader(reader, headerVersion) : default;
+
+        stream.Position = streamStartPosition;
+
+        return result;
     }
 
     public int SkipToContent(TextReader reader)

--- a/src/OfxNet/Sgml/SgmlParser.cs
+++ b/src/OfxNet/Sgml/SgmlParser.cs
@@ -17,14 +17,27 @@ public class SgmlParser
     private SgmlElement lastValueNode = SgmlElement.Empty;
 
     /// <summary>
-    /// Parse teh specified file as an SGML formatted OFX document.
+    /// Parse the specified file as an SGML formatted OFX document.
     /// </summary>
     /// <param name="path">The complete file path to the document to be parsed.</param>
     /// <param name="encoding">The document <see cref="Encoding"/>.</param>
     /// <returns>The root SGML element.</returns>
     public SgmlElement Parse(string path, Encoding encoding)
     {
-        using StreamReader reader = new(path, encoding);
+        using FileStream stream = File.OpenRead(path);
+
+        return this.Parse(stream, encoding);
+    }
+
+    /// <summary>
+    /// Parse the specified file as an SGML formatted OFX document.
+    /// </summary>
+    /// <param name="stream">The stream of the document to be parsed.</param>
+    /// <param name="encoding">The document <see cref="Encoding"/>.</param>
+    /// <returns>The root SGML element.</returns>
+    public SgmlElement Parse(Stream stream, Encoding encoding)
+    {
+        using StreamReader reader = new(stream, encoding, leaveOpen: true);
 
         this.lineNumber = new SgmlHeaderParser().SkipToContent(reader);
 

--- a/test/OfxNet.IntegrationTests/OfxDocumentTests.cs
+++ b/test/OfxNet.IntegrationTests/OfxDocumentTests.cs
@@ -58,6 +58,22 @@ public class OfxDocumentTests
         Assert.AreEqual(txCount, allTransactions.Count());
     }
 
+    [DataTestMethod]
+    [DynamicData(nameof(SampleOfxFiles), DynamicDataSourceType.Property)]
+    public void OfxDocumentLoadStreamGetStatementsReturnsCorrectNumberOfStatementsAndTransactions(string path, int statementCount, int txCount)
+    {
+        using var stream = File.OpenRead(path);
+
+        var actual = OfxDocument.Load(stream);
+        Assert.IsNotNull(actual);
+
+        OfxStatement[] allStatements = actual.GetStatements().ToArray();
+        Assert.AreEqual(statementCount, allStatements.Length);
+
+        IEnumerable<OfxStatementTransaction> allTransactions = allStatements.SelectMany(s => s.TransactionList!.Transactions);
+        Assert.AreEqual(txCount, allTransactions.Count());
+    }
+
     [TestMethod]
     public void CanParseItau()
     {


### PR DESCRIPTION
Adds the ability to load from a stream, rather than just a file path. 

This will allow for more use cases, such as handling an OFX file uploaded to a web application (without first having to save a temporary file).